### PR TITLE
Add impl std::error::Error for FluentError

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,5 @@ byteorder = "^1.0.0"
 clippy = {version = '0.0.116', optional = true}
 
 [dev-dependencies]
+failure = "~0.1.1"
 tempdir = "~0.3"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,7 @@
 //! Implement error types for fruently crate.
 
+use std::error;
+use std::fmt;
 use std::io;
 use retry;
 use serde_json;
@@ -14,6 +16,25 @@ pub enum FluentError {
     FileStored(String),
     #[doc(hidden)]
     Dummy(String),
+}
+
+impl fmt::Display for FluentError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            FluentError::JsonEncode(ref e) => write!(f, "Fluent JSON encode error: {}", e),
+            FluentError::MsgpackEncode(ref e) => write!(f, "Fluent msgpack encode error: {}", e),
+            FluentError::IO(ref e) => write!(f, "Fluent IO error: {}", e),
+            FluentError::Retry(ref e) => write!(f, "Fluent retry error: {}", e),
+            FluentError::FileStored(ref e) => write!(f, "Fluent file stored error: {}", e),
+            FluentError::Dummy(ref e) => write!(f, "Fluent dummy error: {}", e),
+        }
+    }
+}
+
+impl error::Error for FluentError {
+    fn description(&self) -> &str {
+        "FluentError"
+    }
 }
 
 impl From<io::Error> for FluentError {
@@ -37,5 +58,25 @@ impl From<retry::RetryError> for FluentError {
 impl From<serde_json::Error> for FluentError {
     fn from(err: serde_json::Error) -> FluentError {
         FluentError::JsonEncode(err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate failure;
+    use super::*;
+    use self::failure::Error;
+    use std;
+
+    type Result<T> = std::result::Result<T, Error>;
+
+    #[test]
+    fn test_failure_err() {
+        let f = || -> Result<()> {
+            Err(FluentError::Dummy("".to_owned()))?;
+            Ok(())
+        };
+
+        assert!(f().is_err());
     }
 }


### PR DESCRIPTION
Hello @cosmo0920, currently I am using your `fruently` crate, and thanks for your good work! :+1:

I am not sure if you are willing to accept PR, but I would like to add some features as listed below, and hopefully you don't mind.

Changes:
* Add Error trait implementation so that it can be used together with `failure` crate easily.
* Add additional unit test for the trait implementation.

Let me know if you have any comments (e.g. bumping crate version) and thanks!