### PR TITLE
Fix clippy issues

### DIFF
--- a/examples/forward.rs
+++ b/examples/forward.rs
@@ -11,7 +11,7 @@ fn event_time_main() {
     let fruently = Fluent::new("127.0.0.1:24224", "test");
     let mut obj = HashMap::new();
     let time = time::now();
-    let thmap = (0..10).fold(&mut obj, |mut acc, i| {
+    let thmap = (0..10).fold(&mut obj, |acc, i| {
         {
             acc.insert(format!("fwd{}", i), "fruently".to_string());
         }

--- a/src/event_record.rs
+++ b/src/event_record.rs
@@ -1,4 +1,4 @@
-//! Implement EventTime record manupulation mechanisms.
+//! Implement `EventTime` record manupulation mechanisms.
 
 use time;
 use time::Tm;
@@ -50,7 +50,7 @@ impl<T: Serialize> Dumpable for EventRecord<T> {
     fn dump(self) -> String {
         format!(
             "{}\t{}\t{}\n",
-            time::strftime("%FT%T%z", &self.event[0].get_event_time().get_time()).unwrap(),
+            time::strftime("%FT%T%z", self.event[0].get_event_time().get_time()).unwrap(),
             self.tag,
             serde_json::to_string(&self.event[0].get_record()).unwrap()
         )
@@ -59,11 +59,11 @@ impl<T: Serialize> Dumpable for EventRecord<T> {
 
 /// Construct custom encoding json/msgpack style.
 ///
-/// Because `Record` struct should map following style msgpack with ExtType:
+/// Because `Record` struct should map following style msgpack with `ExtType`:
 ///
 /// `[tag, [eventtime, record]]`
 ///
-/// ref: https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#message-modes
+/// ref: <https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#message-modes>
 impl<T: Serialize> Serialize for EventRecord<T> {
     fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         let mut seq = s.serialize_tuple(3)?;

--- a/src/event_time.rs
+++ b/src/event_time.rs
@@ -33,9 +33,9 @@ impl Serialize for EventTime {
         let mut buf = vec![];
         buf.write_u8(0xd7).map_err(Error::custom)?;
         buf.write_u8(0x00).map_err(Error::custom)?;
-        buf.write_i32::<BigEndian>(self.clone().time.clone().to_timespec().sec as i32)
+        buf.write_i32::<BigEndian>(self.clone().time.to_timespec().sec as i32)
             .map_err(Error::custom)?;
-        buf.write_i32::<BigEndian>(self.clone().time.clone().to_timespec().nsec as i32)
+        buf.write_i32::<BigEndian>(self.clone().time.to_timespec().nsec as i32)
             .map_err(Error::custom)?;
         serializer.serialize_bytes(&buf)
     }

--- a/src/fluent.rs
+++ b/src/fluent.rs
@@ -25,11 +25,9 @@ where
 }
 
 #[cfg(feature = "time-as-integer")]
-type MsgPackSendType<T> where
-    T: Serialize = Record<T>;
+type MsgPackSendType<T> = Record<T>;
 #[cfg(not(feature = "time-as-integer"))]
-type MsgPackSendType<T> where
-    T: Serialize = EventRecord<T>;
+type MsgPackSendType<T> = EventRecord<T>;
 
 impl<'a, A: ToSocketAddrs> Fluent<'a, A> {
     /// Create Fluent type.

--- a/src/forwardable/mod.rs
+++ b/src/forwardable/mod.rs
@@ -8,11 +8,9 @@ use serde::ser::Serialize;
 use event_time::EventTime;
 
 #[cfg(not(feature = "time-as-integer"))]
-pub type Entry<T> where
-    T: Serialize = (EventTime, T);
+pub type Entry<T> = (EventTime, T);
 #[cfg(feature = "time-as-integer")]
-pub type Entry<T> where
-    T: Serialize = (i64, T);
+pub type Entry<T> = (i64, T);
 
 pub trait JsonForwardable {
     fn post<T: Serialize + Debug + Clone>(self, record: T) -> Result<(), FluentError>;

--- a/src/record.rs
+++ b/src/record.rs
@@ -41,7 +41,7 @@ impl<T: Serialize> Dumpable for Record<T> {
 ///
 /// `[tag, unixtime/eventtime, record]`
 ///
-/// ref: https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v0#message-mode
+/// ref: <https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v0#message-mode>
 impl<T: Serialize> Serialize for Record<T> {
     fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         let mut seq = s.serialize_tuple(4)?;

--- a/src/retry_conf.rs
+++ b/src/retry_conf.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 ///
 /// `retry_interval = exp ** (multiplier + retry_counts)`
 ///
-/// see: https://github.com/jimmycuadra/retry/blob/v0.4.0/src/lib.rs#L142-L143
+/// see: <https://github.com/jimmycuadra/retry/blob/v0.4.0/src/lib.rs#L142-L143>
 ///
 /// You can estimate to caluculate with concrete values like:
 ///


### PR DESCRIPTION
Fix minor warning issues for `cargo check` / `cargo clippy` / `cargo clippy -- --cfg` test commands.

For reference, the `rustc` version used is `b1f8e6fb0 2018-02-22`, and `cargo-clippy` version is `0.0.186`.